### PR TITLE
feat: Java/Kotlin 혼합 환경에서, Kotlin Lombok Plugin 적용

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 buildscript {
     ext {
         springBootVersion = '2.5.4'
-        kotlinVersion = '1.5.21'
+        kotlinVersion = '1.5.31'
     }
     repositories {
         mavenCentral()
@@ -25,13 +25,7 @@ subprojects {
         plugin('kotlin')
         plugin('kotlin-spring')
         plugin('kotlin-jpa')
-        plugin("org.jetbrains.kotlin.plugin.spring")
-        plugin("org.jetbrains.kotlin.jvm")
-        plugin("org.jetbrains.kotlin.kapt")
-    }
-
-    kapt {
-        keepJavacAnnotationProcessors = true
+        plugin('kotlin-kapt')
     }
 
     sourceCompatibility = '11'
@@ -49,6 +43,10 @@ subprojects {
 
     repositories {
         mavenCentral()
+    }
+
+    kapt {
+        keepJavacAnnotationProcessors = true
     }
 
     dependencies {

--- a/build.gradle
+++ b/build.gradle
@@ -30,6 +30,10 @@ subprojects {
         plugin("org.jetbrains.kotlin.kapt")
     }
 
+    kapt {
+        keepJavacAnnotationProcessors = true
+    }
+
     sourceCompatibility = '11'
 
     compileKotlin {

--- a/dgdg-domain/build.gradle
+++ b/dgdg-domain/build.gradle
@@ -1,17 +1,6 @@
 bootJar { enabled = false }
 jar { enabled = true }
 
-noArg {
-    annotation("javax.persistence.Entity")
-    annotation("javax.persistence.MappedSuperclass")
-    annotation("javax.persistence.Embeddable")
-}
-allOpen {
-    annotation("javax.persistence.Entity")
-    annotation("javax.persistence.MappedSuperclass")
-    annotation("javax.persistence.Embeddable")
-}
-
 dependencies {
     implementation project(":dgdg-common")
 


### PR DESCRIPTION
# 코틀린 자바 롬복 호환성 이슈 해결 플러그인
https://kotlinlang.org/docs/lombok.html
실험용 플러그인이긴 하지만.. (~~뭐.... 사이드 플젝이니깐? ㅎㅎㅎ~~)


저희처럼 자바 + 코틀린을 혼합해서 사용하는 프로젝트에서 다음 이슈(https://github.com/depromeet/dgdg-backend/pull/1 )해결 가능합니다.. 
(테스트 해보니 일단은... QueryDSL도 문제없이 사용 가능하네요!)


- 자바 + 코틀린로 도메인 모듈 코드 작성 가능
- 자바 코드 작성시 롬복 사용 가능


이 플러그인을 적용한다면 저희 회의때 결정한 "롬복을 사용하고, 도메인 모듈은 자바 코드로만 작성한다." 정책이 없어져도 될 것 같습니다.

