### PR TITLE
feat: 회원정보를 조회 및 수정 API,  토큰 재발급 API, 로그아웃 API

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,7 @@ buildscript {
     ext {
         springBootVersion = '2.5.4'
         kotlinVersion = '1.5.31'
+        kotestVersion = '4.4.3'
     }
     repositories {
         mavenCentral()
@@ -34,11 +35,13 @@ subprojects {
     compileKotlin {
         kotlinOptions {
             jvmTarget = "11"
+            freeCompilerArgs = ["-Xjsr305=strict"]
         }
     }
     compileTestKotlin {
         kotlinOptions {
             jvmTarget = "11"
+            freeCompilerArgs = ["-Xjsr305=strict"]
         }
     }
 
@@ -71,6 +74,10 @@ subprojects {
 
         implementation 'org.springframework.boot:spring-boot-starter-webflux'
         implementation 'org.projectreactor:reactor-spring:1.0.1.RELEASE'
+
+        // kotest
+        testImplementation("io.kotest:kotest-runner-junit5:${kotestVersion}")
+        testImplementation("io.kotest:kotest-extensions-spring:${kotestVersion}")
 
     }
 

--- a/dgdg-api/src/main/java/com/depromeet/dgdg/config/auth/AuthResponse.java
+++ b/dgdg-api/src/main/java/com/depromeet/dgdg/config/auth/AuthResponse.java
@@ -8,9 +8,12 @@ import lombok.ToString;
 @Getter
 @RequiredArgsConstructor
 public class AuthResponse {
-    private final String socialId;
 
-    public static AuthResponse of(String socialId) {
-        return new AuthResponse(socialId);
+    private final String accessToken;
+    private final String refreshToken;
+
+    public static AuthResponse of(String accessToken, String refreshToken) {
+        return new AuthResponse(accessToken, refreshToken);
     }
+
 }

--- a/dgdg-api/src/main/java/com/depromeet/dgdg/config/auth/UserIdArgumentResolver.kt
+++ b/dgdg-api/src/main/java/com/depromeet/dgdg/config/auth/UserIdArgumentResolver.kt
@@ -11,9 +11,8 @@ import org.springframework.web.method.support.ModelAndViewContainer
 class UserIdArgumentResolver : HandlerMethodArgumentResolver {
 
     override fun supportsParameter(parameter: MethodParameter): Boolean {
-        return parameter.getMethodAnnotation(RequiredAuth::class.java) != null
-            && parameter.getParameterAnnotation(UserId::class.java) != null
-            && parameter.parameterType.equals(Long::class.java)
+        return parameter.getParameterAnnotation(UserId::class.java) != null
+            && parameter.parameterType == Long::class.java
     }
 
     override fun resolveArgument(
@@ -22,6 +21,10 @@ class UserIdArgumentResolver : HandlerMethodArgumentResolver {
         webRequest: NativeWebRequest,
         binderFactory: WebDataBinderFactory?
     ): Any? {
+        if (parameter.getMethodAnnotation(RequiredAuth::class.java) == null) {
+            throw IllegalArgumentException("인증이 필요한 컨트롤러에 @RequiredAuth 어노테이션을 추가해주세요")
+        }
+
         return webRequest.getAttribute(AuthConstants.USER_ID_FIELD, 0)
     }
 

--- a/dgdg-api/src/main/java/com/depromeet/dgdg/controller/LocalTestController.kt
+++ b/dgdg-api/src/main/java/com/depromeet/dgdg/controller/LocalTestController.kt
@@ -1,0 +1,31 @@
+package com.depromeet.dgdg.controller
+
+import com.depromeet.dgdg.controller.dto.response.BaseResponse
+import com.depromeet.dgdg.domain.domain.user.User
+import com.depromeet.dgdg.domain.domain.user.repository.UserRepository
+import com.depromeet.dgdg.provider.token.AuthTokenProvider
+import com.depromeet.dgdg.provider.token.dto.AuthTokenPayload
+import org.springframework.context.annotation.Profile
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RestController
+
+@Profile("dev", "local")
+@RestController
+class LocalTestController(
+    private val userRepository: UserRepository,
+    private val tokenProvider: AuthTokenProvider<AuthTokenPayload>
+) {
+
+    @GetMapping("/test-token")
+    fun getTestToken(): BaseResponse<String> {
+        val user = userRepository.findBySocialIdAndSocialProvider(user.socialId, user.socialProvider)
+            .orElseGet { user }
+        userRepository.save(user)
+        return BaseResponse.success(tokenProvider.createAccessToken(AuthTokenPayload(user.id)))
+    }
+
+    companion object {
+        val user: User = User.newKaKaoInstance("test-social-id", "테스트 계정", "https://profile.com")
+    }
+
+}

--- a/dgdg-api/src/main/java/com/depromeet/dgdg/controller/advice/ControllerExceptionAdvice.kt
+++ b/dgdg-api/src/main/java/com/depromeet/dgdg/controller/advice/ControllerExceptionAdvice.kt
@@ -7,6 +7,7 @@ import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
+import org.springframework.validation.BindException
 import org.springframework.web.bind.annotation.ExceptionHandler
 import org.springframework.web.bind.annotation.ResponseStatus
 import org.springframework.web.bind.annotation.RestControllerAdvice
@@ -16,6 +17,13 @@ class ControllerExceptionAdvice {
 
     private val log: Logger
         get() = LoggerFactory.getLogger(ControllerExceptionAdvice::class.java)
+
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    @ExceptionHandler(BindException::class)
+    protected fun handleBadRequest(e: BindException): BaseResponse<Nothing> {
+        log.error(e.message)
+        return BaseResponse.error(BAD_REQUEST_EXCEPTION.code, e.bindingResult.fieldError?.defaultMessage)
+    }
 
     @ExceptionHandler(DgDgBaseException::class)
     fun handleInternalServerException(exception: DgDgBaseException): ResponseEntity<BaseResponse<Nothing>> {

--- a/dgdg-api/src/main/java/com/depromeet/dgdg/controller/auth/AuthController.kt
+++ b/dgdg-api/src/main/java/com/depromeet/dgdg/controller/auth/AuthController.kt
@@ -1,0 +1,37 @@
+package com.depromeet.dgdg.controller.auth
+
+import com.depromeet.dgdg.config.auth.RequiredAuth
+import com.depromeet.dgdg.config.auth.UserId
+import com.depromeet.dgdg.controller.dto.response.BaseResponse
+import com.depromeet.dgdg.service.auth.AuthService
+import com.depromeet.dgdg.service.auth.dto.request.RefreshTokenRequest
+import com.depromeet.dgdg.service.auth.dto.response.RefreshTokenResponse
+import io.swagger.annotations.ApiOperation
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RestController
+import javax.validation.Valid
+
+@RestController
+class AuthController(
+    private val authService: AuthService
+) {
+
+    @ApiOperation("로그아웃 API(Refresh Token 만료)")
+    @RequiredAuth
+    @PostMapping("/api/v1/logout")
+    fun logout(@UserId userId: Long): BaseResponse<String> {
+        authService.logout(userId)
+        return BaseResponse.OK
+    }
+
+    @ApiOperation("액세스 토큰을 재발급 받는 API")
+    @PostMapping("/api/v1/refresh/token")
+    fun refreshAccessToken(
+        @Valid @RequestBody request: RefreshTokenRequest
+    ): BaseResponse<RefreshTokenResponse> {
+        val accessToken = authService.refreshAccessToken(request)
+        return BaseResponse.success(RefreshTokenResponse(accessToken))
+    }
+
+}

--- a/dgdg-api/src/main/java/com/depromeet/dgdg/controller/auth/KakaoLoginController.java
+++ b/dgdg-api/src/main/java/com/depromeet/dgdg/controller/auth/KakaoLoginController.java
@@ -4,8 +4,6 @@ import com.depromeet.dgdg.config.auth.AuthResponse;
 import com.depromeet.dgdg.service.auth.KakaoLoginService;
 import com.depromeet.dgdg.service.auth.dto.request.AuthRequest;
 import com.depromeet.dgdg.controller.dto.response.BaseResponse;
-import com.depromeet.dgdg.provider.token.JwtAuthTokenProvider;
-import com.depromeet.dgdg.provider.token.dto.AuthTokenPayload;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
@@ -16,13 +14,10 @@ import javax.validation.Valid;
 public class KakaoLoginController {
 
     private final KakaoLoginService kakaoLoginService;
-    private final JwtAuthTokenProvider jwtAuthTokenProvider;
 
     @PostMapping("/api/v1/auth/kakao")
-    public BaseResponse<AuthResponse> kakaoAuth(@Valid @RequestBody AuthRequest request) {
-        Long memberId = kakaoLoginService.handleAuthentication(request);
-        String token = jwtAuthTokenProvider.createAccessToken(AuthTokenPayload.of(memberId));
-        return BaseResponse.success(AuthResponse.of(token));
+    public BaseResponse<AuthResponse> handleKakaoAuthentication(@Valid @RequestBody AuthRequest request) {
+        return BaseResponse.success(kakaoLoginService.handleAuthentication(request));
     }
 
 }

--- a/dgdg-api/src/main/java/com/depromeet/dgdg/controller/user/UserController.kt
+++ b/dgdg-api/src/main/java/com/depromeet/dgdg/controller/user/UserController.kt
@@ -6,6 +6,7 @@ import com.depromeet.dgdg.controller.dto.response.BaseResponse
 import com.depromeet.dgdg.service.user.UserService
 import com.depromeet.dgdg.service.user.dto.request.UserRequest
 import com.depromeet.dgdg.service.user.dto.response.UserInfoResponse
+import io.swagger.annotations.ApiOperation
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PutMapping
 import org.springframework.web.bind.annotation.RequestBody
@@ -16,6 +17,7 @@ class UserController(
     private val userService: UserService
 ) {
 
+    @ApiOperation("유저의 회원 정보를 조회하는 API")
     @RequiredAuth
     @GetMapping("/api/v1/user/me")
     fun getMyUserInfo(
@@ -24,6 +26,7 @@ class UserController(
         return BaseResponse.success(userService.getUserInfo(userId))
     }
 
+    @ApiOperation("유저의 회원 정보를 수정하는 API")
     @RequiredAuth
     @PutMapping("/api/v1/user/me")
     fun updateMyUserInfo(

--- a/dgdg-api/src/main/java/com/depromeet/dgdg/controller/user/UserController.kt
+++ b/dgdg-api/src/main/java/com/depromeet/dgdg/controller/user/UserController.kt
@@ -1,0 +1,36 @@
+package com.depromeet.dgdg.controller.user
+
+import com.depromeet.dgdg.config.auth.RequiredAuth
+import com.depromeet.dgdg.config.auth.UserId
+import com.depromeet.dgdg.controller.dto.response.BaseResponse
+import com.depromeet.dgdg.service.user.UserService
+import com.depromeet.dgdg.service.user.dto.request.UserRequest
+import com.depromeet.dgdg.service.user.dto.response.UserInfoResponse
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PutMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+class UserController(
+    private val userService: UserService
+) {
+
+    @RequiredAuth
+    @GetMapping("/api/v1/user/me")
+    fun getMyUserInfo(
+        @UserId userId: Long
+    ): BaseResponse<UserInfoResponse> {
+        return BaseResponse.success(userService.getUserInfo(userId))
+    }
+
+    @RequiredAuth
+    @PutMapping("/api/v1/user/me")
+    fun updateMyUserInfo(
+        @RequestBody request: UserRequest,
+        @UserId userId: Long
+    ): BaseResponse<UserInfoResponse> {
+        return BaseResponse.success(userService.updateUserInfo(request, userId))
+    }
+
+}

--- a/dgdg-api/src/main/java/com/depromeet/dgdg/provider/token/AuthTokenProvider.kt
+++ b/dgdg-api/src/main/java/com/depromeet/dgdg/provider/token/AuthTokenProvider.kt
@@ -6,4 +6,6 @@ interface AuthTokenProvider<T> {
 
     fun getPayload(token: String): T
 
+    fun createRefreshToken(): String
+
 }

--- a/dgdg-api/src/main/java/com/depromeet/dgdg/provider/token/dto/JwtProperties.kt
+++ b/dgdg-api/src/main/java/com/depromeet/dgdg/provider/token/dto/JwtProperties.kt
@@ -8,5 +8,6 @@ import org.springframework.boot.context.properties.ConstructorBinding
 data class JwtProperties(
     val issuer: String,
     val secret: String,
-    val expiresTime: Long
+    val accessTokenExpiresTime: Long,
+    val refreshTokenExpiresTime: Long
 )

--- a/dgdg-api/src/main/java/com/depromeet/dgdg/service/auth/AuthService.kt
+++ b/dgdg-api/src/main/java/com/depromeet/dgdg/service/auth/AuthService.kt
@@ -1,0 +1,31 @@
+package com.depromeet.dgdg.service.auth
+
+import com.depromeet.dgdg.common.exception.UnAuthorizedException
+import com.depromeet.dgdg.domain.domain.user.repository.UserRepository
+import com.depromeet.dgdg.provider.token.AuthTokenProvider
+import com.depromeet.dgdg.provider.token.dto.AuthTokenPayload
+import com.depromeet.dgdg.service.auth.dto.request.RefreshTokenRequest
+import com.depromeet.dgdg.service.user.findUserById
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+class AuthService(
+    private val userRepository: UserRepository,
+    private val authTokenProvider: AuthTokenProvider<AuthTokenPayload>
+) {
+
+    @Transactional
+    fun logout(userId: Long) {
+        val user = findUserById(userRepository, userId)
+        user.removeRefreshToken()
+    }
+
+    @Transactional(readOnly = true)
+    fun refreshAccessToken(request: RefreshTokenRequest): String {
+        val user = userRepository.findByRefreshToken(request.refreshToken)
+            ?: throw UnAuthorizedException("유효하지 않은 Refresh token (${request.refreshToken}) 입니다")
+        return authTokenProvider.createAccessToken(AuthTokenPayload.of(user.id))
+    }
+
+}

--- a/dgdg-api/src/main/java/com/depromeet/dgdg/service/auth/dto/request/AuthRequest.java
+++ b/dgdg-api/src/main/java/com/depromeet/dgdg/service/auth/dto/request/AuthRequest.java
@@ -13,7 +13,7 @@ import javax.validation.constraints.NotBlank;
 @NoArgsConstructor
 public class AuthRequest {
 
-    @NotBlank
+    @NotBlank(message = "accessToken을 입력해주세요.")
     private String accessToken;
 
 }

--- a/dgdg-api/src/main/java/com/depromeet/dgdg/service/auth/dto/request/RefreshTokenRequest.kt
+++ b/dgdg-api/src/main/java/com/depromeet/dgdg/service/auth/dto/request/RefreshTokenRequest.kt
@@ -1,0 +1,8 @@
+package com.depromeet.dgdg.service.auth.dto.request
+
+import javax.validation.constraints.NotBlank
+
+data class RefreshTokenRequest(
+    @get:NotBlank(message = "refreshToken을 입력해주세요")
+    val refreshToken: String
+)

--- a/dgdg-api/src/main/java/com/depromeet/dgdg/service/auth/dto/response/RefreshTokenResponse.kt
+++ b/dgdg-api/src/main/java/com/depromeet/dgdg/service/auth/dto/response/RefreshTokenResponse.kt
@@ -1,0 +1,5 @@
+package com.depromeet.dgdg.service.auth.dto.response
+
+data class RefreshTokenResponse(
+    val accessToken: String
+)

--- a/dgdg-api/src/main/java/com/depromeet/dgdg/service/user/UserService.kt
+++ b/dgdg-api/src/main/java/com/depromeet/dgdg/service/user/UserService.kt
@@ -1,0 +1,34 @@
+package com.depromeet.dgdg.service.user
+
+import com.depromeet.dgdg.common.exception.NotFoundException
+import com.depromeet.dgdg.domain.domain.user.User
+import com.depromeet.dgdg.domain.domain.user.repository.UserRepository
+import com.depromeet.dgdg.service.user.dto.request.UserRequest
+import com.depromeet.dgdg.service.user.dto.response.UserInfoResponse
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+class UserService(
+    private val userRepository: UserRepository
+) {
+
+    @Transactional(readOnly = true)
+    fun getUserInfo(userId: Long): UserInfoResponse {
+        val user = findUserById(userRepository, userId)
+        return UserInfoResponse.of(user)
+    }
+
+    @Transactional
+    fun updateUserInfo(request: UserRequest, userId: Long): UserInfoResponse {
+        val user = findUserById(userRepository, userId)
+        user.updateInfo(request.name, request.profileUrl)
+        return UserInfoResponse.of(user)
+    }
+
+}
+
+fun findUserById(userRepository: UserRepository, userId: Long): User {
+    return userRepository.findUserById(userId)
+        ?: throw NotFoundException("해당하는 유저 ($userId)는 존재하지 않습니다")
+}

--- a/dgdg-api/src/main/java/com/depromeet/dgdg/service/user/dto/request/UserRequest.kt
+++ b/dgdg-api/src/main/java/com/depromeet/dgdg/service/user/dto/request/UserRequest.kt
@@ -1,0 +1,6 @@
+package com.depromeet.dgdg.service.user.dto.request
+
+data class UserRequest(
+    val name: String,
+    val profileUrl: String?
+)

--- a/dgdg-api/src/main/java/com/depromeet/dgdg/service/user/dto/response/UserResponse.kt
+++ b/dgdg-api/src/main/java/com/depromeet/dgdg/service/user/dto/response/UserResponse.kt
@@ -1,0 +1,18 @@
+package com.depromeet.dgdg.service.user.dto.response
+
+import com.depromeet.dgdg.domain.domain.user.SocialProvider
+import com.depromeet.dgdg.domain.domain.user.User
+
+data class UserInfoResponse(
+    val socialProvider: SocialProvider,
+    val name: String,
+    val profileUrl: String?
+) {
+
+    companion object {
+        fun of(user: User): UserInfoResponse {
+            return UserInfoResponse(user.socialProvider, user.name, user.profileUrl)
+        }
+    }
+
+}

--- a/dgdg-api/src/main/resources/application-jwt.yml
+++ b/dgdg-api/src/main/resources/application-jwt.yml
@@ -1,7 +1,8 @@
 jwt:
   issuer: dgdg-local
   secret: dgdg-local-test-key
-  expires_time: 86400 # 1일 (60 * 60 * 24)
+  access_token_expires_time: 86400 # 1일 (60 * 60 * 24)
+  refresh_token_expires_time: 2592000 # 30일 (60 * 60 & 24 * 30)
 spring:
   config:
     activate:
@@ -11,6 +12,7 @@ jwt:
   issuer: ${jwt-issuer}
   secret: ${jwt-secret}
   expires_time: 86400 # 1일 (60 * 60 * 24)
+  refresh_token_expires_time: 2592000 # 30일 (60 * 60 & 24 * 30)
 spring:
   config:
     activate:

--- a/dgdg-api/src/test/java/com/depromeet/dgdg/provider/token/JwtAuthTokenProviderTest.kt
+++ b/dgdg-api/src/test/java/com/depromeet/dgdg/provider/token/JwtAuthTokenProviderTest.kt
@@ -52,4 +52,16 @@ internal class JwtAuthTokenProviderTest(
         assertThatThrownBy { jwtAuthTokenProvider.getPayload(token) }.isInstanceOf(UnAuthorizedException::class.java)
     }
 
+    @Test
+    fun payload가_없는_RefreshToken을_생성한다() {
+        // when
+        val refreshToken = jwtAuthTokenProvider.createRefreshToken()
+
+        // then
+        assertAll({
+            assertThat(refreshToken).isNotNull
+            assertThat(refreshToken.startsWith("ey")).isTrue
+        })
+    }
+
 }

--- a/dgdg-api/src/test/java/com/depromeet/dgdg/service/auth/AuthServiceTest.kt
+++ b/dgdg-api/src/test/java/com/depromeet/dgdg/service/auth/AuthServiceTest.kt
@@ -1,0 +1,81 @@
+package com.depromeet.dgdg.service.auth
+
+import com.depromeet.dgdg.common.exception.NotFoundException
+import com.depromeet.dgdg.common.exception.UnAuthorizedException
+import com.depromeet.dgdg.domain.domain.user.SocialProvider
+import com.depromeet.dgdg.domain.domain.user.UserCreator
+import com.depromeet.dgdg.domain.domain.user.repository.UserRepository
+import com.depromeet.dgdg.service.auth.dto.request.RefreshTokenRequest
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import io.kotest.matchers.string.shouldStartWith
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.springframework.boot.test.context.SpringBootTest
+
+@SpringBootTest
+internal class AuthServiceTest(
+    private val authService: AuthService,
+    private val userRepository: UserRepository
+) : FunSpec({
+
+    afterEach {
+        userRepository.deleteAll()
+    }
+
+    val user = UserCreator.create(
+        socialId = "social-id",
+        socialProvider = SocialProvider.KAKAO,
+        name = "득근득근",
+        profileUrl = "https://dgdg.profile.com"
+    )
+
+    context("로그아웃") {
+        test("로그아웃시 유저의 Refresh Token을 삭제한다") {
+            // given
+            user.updateRefreshToken("Refresh-Token")
+            userRepository.save(user)
+
+            // when
+            authService.logout(user.id)
+
+            // then
+            val users = userRepository.findAll()
+            users shouldHaveSize 1
+            users[0].refreshToken shouldBe null
+        }
+
+        test("해당하는 유저가 존재하지 않는 경우 404 에러가 발생한다") {
+            // when & then
+            assertThatThrownBy { authService.logout(999L) }.isInstanceOf(NotFoundException::class.java)
+        }
+    }
+
+    context("액세스 토큰 재발급") {
+        test("RefreshToken을 가지고 있는 사용자를 찾아서 액세스 토큰을 재발급한다") {
+            // given
+            val refreshToken = "refresh-token"
+            user.updateRefreshToken(refreshToken)
+            userRepository.save(user)
+
+            // when
+            val accessToken = authService.refreshAccessToken(RefreshTokenRequest(refreshToken))
+
+            // then
+            accessToken shouldNotBe null
+            accessToken shouldStartWith "ey"
+        }
+
+        test("유효하지 않은 RefreshToken인 경우 401 에러가 발생한다") {
+            // given
+            val refreshToken = "Invalid-refresh-token"
+
+            // when & then
+            assertThatThrownBy { authService.refreshAccessToken(RefreshTokenRequest(refreshToken)) }.isInstanceOf(
+                UnAuthorizedException::class.java
+            )
+        }
+    }
+
+})

--- a/dgdg-api/src/test/java/com/depromeet/dgdg/service/user/UserServiceTest.kt
+++ b/dgdg-api/src/test/java/com/depromeet/dgdg/service/user/UserServiceTest.kt
@@ -1,0 +1,65 @@
+package com.depromeet.dgdg.service.user
+
+import com.depromeet.dgdg.common.exception.NotFoundException
+import com.depromeet.dgdg.domain.domain.user.SocialProvider
+import com.depromeet.dgdg.domain.domain.user.UserCreator
+import com.depromeet.dgdg.domain.domain.user.repository.UserRepository
+import com.depromeet.dgdg.service.user.dto.request.UserRequest
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.shouldBe
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.springframework.boot.test.context.SpringBootTest
+
+@SpringBootTest
+internal class UserServiceTest(
+    private val userService: UserService,
+    private val userRepository: UserRepository
+) : FunSpec({
+
+    afterEach {
+        userRepository.deleteAll()
+    }
+
+    val user = UserCreator.create(
+        socialId = "social-id",
+        socialProvider = SocialProvider.KAKAO,
+        name = "득근득근",
+        profileUrl = "https://dgdg.profile.com"
+    )
+
+    context("유저의 회원정보 수정") {
+        test("회원정보 수정을 요청하면 DB의 해당하는 유저의 회원 정보가 변경된다") {
+            // given
+            userRepository.save(user)
+
+            val request = UserRequest("will", "https://will.profile.com")
+
+            // when
+            userService.updateUserInfo(request, user.id)
+
+            // then
+            val users = userRepository.findAll()
+            users shouldHaveSize 1
+            users[0].name shouldBe request.name
+            users[0].profileUrl shouldBe request.profileUrl
+            users[0].socialId shouldBe user.socialId
+            users[0].socialProvider shouldBe user.socialProvider
+        }
+
+        test("존재하지 않는 유저인 경우 NotFound 에러 발생") {
+            // given
+            val userId = 999L
+            val request = UserRequest("will", "https://will.profile.com")
+
+            // when & then
+            assertThatThrownBy {
+                userService.updateUserInfo(
+                    request,
+                    userId
+                )
+            }.isInstanceOf(NotFoundException::class.java)
+        }
+    }
+
+})

--- a/dgdg-domain/src/main/java/com/depromeet/dgdg/domain/domain/user/User.java
+++ b/dgdg-domain/src/main/java/com/depromeet/dgdg/domain/domain/user/User.java
@@ -55,4 +55,12 @@ public class User extends BaseTimeEntity {
         this.profileUrl = profileUrl;
     }
 
+    public void updateRefreshToken(String refreshToken) {
+        this.refreshToken = refreshToken;
+    }
+
+    public void removeRefreshToken() {
+        this.refreshToken = null;
+    }
+
 }

--- a/dgdg-domain/src/main/java/com/depromeet/dgdg/domain/domain/user/User.java
+++ b/dgdg-domain/src/main/java/com/depromeet/dgdg/domain/domain/user/User.java
@@ -5,6 +5,7 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.jetbrains.annotations.NotNull;
 
 import javax.persistence.*;
 
@@ -33,7 +34,7 @@ public class User extends BaseTimeEntity {
     private String refreshToken;
 
     @Builder(access = AccessLevel.PRIVATE)
-    private User(String socialId, SocialProvider socialProvider, String name, String profileUrl) {
+    User(String socialId, SocialProvider socialProvider, String name, String profileUrl) {
         this.socialId = socialId;
         this.socialProvider = socialProvider;
         this.name = name;
@@ -47,6 +48,11 @@ public class User extends BaseTimeEntity {
             .name(name)
             .profileUrl(profileUrl)
             .build();
+    }
+
+    public void updateInfo(@NotNull String name, String profileUrl) {
+        this.name = name;
+        this.profileUrl = profileUrl;
     }
 
 }

--- a/dgdg-domain/src/main/java/com/depromeet/dgdg/domain/domain/user/UserCreator.kt
+++ b/dgdg-domain/src/main/java/com/depromeet/dgdg/domain/domain/user/UserCreator.kt
@@ -1,0 +1,9 @@
+package com.depromeet.dgdg.domain.domain.user
+
+object UserCreator {
+
+    fun create(socialId: String, socialProvider: SocialProvider, name: String, profileUrl: String): User {
+        return User(socialId, socialProvider, name, profileUrl)
+    }
+
+}

--- a/dgdg-domain/src/main/java/com/depromeet/dgdg/domain/domain/user/repository/UserRepositoryCustom.java
+++ b/dgdg-domain/src/main/java/com/depromeet/dgdg/domain/domain/user/repository/UserRepositoryCustom.java
@@ -1,8 +1,9 @@
 package com.depromeet.dgdg.domain.domain.user.repository;
 
-import com.depromeet.dgdg.domain.domain.user.SocialProvider;
 import com.depromeet.dgdg.domain.domain.user.User;
 
 public interface UserRepositoryCustom {
+
+    User findUserById(Long userId);
 
 }

--- a/dgdg-domain/src/main/java/com/depromeet/dgdg/domain/domain/user/repository/UserRepositoryCustom.java
+++ b/dgdg-domain/src/main/java/com/depromeet/dgdg/domain/domain/user/repository/UserRepositoryCustom.java
@@ -1,9 +1,12 @@
 package com.depromeet.dgdg.domain.domain.user.repository;
 
 import com.depromeet.dgdg.domain.domain.user.User;
+import org.jetbrains.annotations.NotNull;
 
 public interface UserRepositoryCustom {
 
     User findUserById(Long userId);
+
+    User findByRefreshToken(@NotNull String refreshToken);
 
 }

--- a/dgdg-domain/src/main/java/com/depromeet/dgdg/domain/domain/user/repository/UserRepositoryCustomImpl.java
+++ b/dgdg-domain/src/main/java/com/depromeet/dgdg/domain/domain/user/repository/UserRepositoryCustomImpl.java
@@ -1,9 +1,22 @@
 package com.depromeet.dgdg.domain.domain.user.repository;
 
+import com.depromeet.dgdg.domain.domain.user.User;
+import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 
+import static com.depromeet.dgdg.domain.domain.user.QUser.user;
 
 @RequiredArgsConstructor
 public class UserRepositoryCustomImpl implements UserRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public User findUserById(Long userId) {
+        return queryFactory.selectFrom(user)
+            .where(
+                user.id.eq(userId)
+            ).fetchOne();
+    }
 
 }

--- a/dgdg-domain/src/main/java/com/depromeet/dgdg/domain/domain/user/repository/UserRepositoryCustomImpl.java
+++ b/dgdg-domain/src/main/java/com/depromeet/dgdg/domain/domain/user/repository/UserRepositoryCustomImpl.java
@@ -3,6 +3,7 @@ package com.depromeet.dgdg.domain.domain.user.repository;
 import com.depromeet.dgdg.domain.domain.user.User;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
+import org.jetbrains.annotations.NotNull;
 
 import static com.depromeet.dgdg.domain.domain.user.QUser.user;
 
@@ -16,6 +17,14 @@ public class UserRepositoryCustomImpl implements UserRepositoryCustom {
         return queryFactory.selectFrom(user)
             .where(
                 user.id.eq(userId)
+            ).fetchOne();
+    }
+
+    @Override
+    public User findByRefreshToken(@NotNull String refreshToken) {
+        return queryFactory.selectFrom(user)
+            .where(
+                user.refreshToken.eq(refreshToken)
             ).fetchOne();
     }
 


### PR DESCRIPTION
### 기능 추가
- 회원 정보 조회 및 수정 API
- RefreshToken을 통해 accessToken을 재발급하는 API
- 로그아웃 API

### 수정 사항
- 카카오 로그인 성공시 accesesToken과 함께 RefreshToken을 반환

### 이슈
- kotest